### PR TITLE
feat: integrate student agenda with backend events

### DIFF
--- a/backend/src/modules/aluno/aluno.controller.ts
+++ b/backend/src/modules/aluno/aluno.controller.ts
@@ -49,4 +49,48 @@ export const alunoController = {
       next(error);
     }
   },
+
+  getAgendaMensal: async (
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+  ) => {
+    try {
+      if (!req.user?.perfilId) {
+        return res.status(403).json({
+          message: "Perfil de aluno não encontrado para o usuário autenticado.",
+        });
+      }
+
+      const parseDate = (value: unknown) => {
+        if (!value) return null;
+        const raw = Array.isArray(value) ? value[0] : value;
+        const parsed = new Date(String(raw));
+        return Number.isNaN(parsed.getTime()) ? null : parsed;
+      };
+
+      const today = new Date();
+      const defaultStart = new Date(today.getFullYear(), today.getMonth(), 1);
+      const defaultEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+
+      const startDate = parseDate(req.query.start) ?? defaultStart;
+      const endDate = parseDate(req.query.end) ?? defaultEnd;
+
+      if (startDate > endDate) {
+        return res.status(400).json({
+          message: "A data inicial não pode ser maior que a data final.",
+        });
+      }
+
+      const eventos = await alunoService.getAgendaEventos(
+        req.user,
+        startDate,
+        endDate
+      );
+
+      res.json({ eventos });
+    } catch (error) {
+      next(error);
+    }
+  },
 };

--- a/backend/src/modules/aluno/aluno.routes.ts
+++ b/backend/src/modules/aluno/aluno.routes.ts
@@ -13,6 +13,13 @@ router.get(
   alunoController.getBoletim
 );
 
+router.get(
+  "/agenda",
+  protect,
+  authorize("ALUNO"),
+  alunoController.getAgendaMensal
+);
+
 // Rota para buscar os dados de um aluno específico (incluindo seu nome)
 router.get(
   "/:id",

--- a/backend/src/modules/aluno/aluno.service.ts
+++ b/backend/src/modules/aluno/aluno.service.ts
@@ -1,4 +1,5 @@
-import { PrismaClient } from "@prisma/client";
+import { DiaDaSemana, PrismaClient } from "@prisma/client";
+import { AuthenticatedRequest } from "../../middlewares/auth";
 
 const prisma = new PrismaClient();
 
@@ -173,8 +174,232 @@ async function getBoletim(usuarioId: string) {
   return boletimFinal;
 }
 
+type AgendaEventoTipo =
+  | "Aula"
+  | "Prova"
+  | "Trabalho"
+  | "Tarefa"
+  | "Recuperação"
+  | "Reunião"
+  | "Feriado"
+  | "Evento Escolar";
+
+type AgendaEvento = {
+  id: string;
+  date: Date;
+  type: AgendaEventoTipo;
+  title: string;
+  details?: string;
+  time?: string;
+};
+
+const diaSemanaMap: Record<DiaDaSemana, number> = {
+  DOMINGO: 0,
+  SEGUNDA: 1,
+  TERCA: 2,
+  QUARTA: 3,
+  QUINTA: 4,
+  SEXTA: 5,
+  SABADO: 6,
+};
+
+const tipoMap: Record<string, AgendaEventoTipo> = {
+  AULA: "Aula",
+  PROVA: "Prova",
+  TRABALHO: "Trabalho",
+  TAREFA: "Tarefa",
+  RECUPERACAO: "Recuperação",
+  RECUPERACAO_FINAL: "Recuperação",
+  REUNIAO: "Reunião",
+  FERIADO: "Feriado",
+  EVENTO_ESCOLAR: "Evento Escolar",
+};
+
+const startOfDay = (date: Date) => {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+};
+
+const endOfDay = (date: Date) => {
+  const d = new Date(date);
+  d.setHours(23, 59, 59, 999);
+  return d;
+};
+
+const addDays = (date: Date, amount: number) => {
+  const d = new Date(date);
+  d.setDate(d.getDate() + amount);
+  return d;
+};
+
+const formatDateKey = (date: Date) => date.toISOString().slice(0, 10);
+
+const formatTime = (date: Date | null | undefined) => {
+  if (!date || Number.isNaN(date.getTime())) return undefined;
+  return date.toISOString().slice(11, 16);
+};
+
+async function getAgendaEventos(
+  user: AuthenticatedRequest["user"],
+  rangeStart: Date,
+  rangeEnd: Date
+) {
+  if (!user?.perfilId) {
+    return [];
+  }
+
+  const start = startOfDay(rangeStart);
+  const end = endOfDay(rangeEnd);
+
+  const matriculaAtiva = await prisma.matriculas.findFirst({
+    where: { alunoId: user.perfilId, status: "ATIVA" },
+    select: { turmaId: true },
+  });
+
+  if (!matriculaAtiva) {
+    return [];
+  }
+
+  const [horarios, tarefas, eventosGerais] = await Promise.all([
+    prisma.horarioAula.findMany({
+      where: { turmaId: matriculaAtiva.turmaId },
+      include: {
+        componenteCurricular: {
+          select: { materia: { select: { nome: true } } },
+        },
+        turma: { select: { nome: true } },
+      },
+    }),
+    prisma.tarefas.findMany({
+      where: {
+        publicado: true,
+        data_entrega: {
+          gte: start,
+          lte: end,
+        },
+        componenteCurricular: { turmaId: matriculaAtiva.turmaId },
+      },
+      include: {
+        componenteCurricular: {
+          select: { materia: { select: { nome: true } } },
+        },
+      },
+    }),
+    prisma.eventosCalendario.findMany({
+      where: {
+        ...(user.unidadeEscolarId
+          ? { unidadeEscolarId: user.unidadeEscolarId }
+          : {}),
+        data_inicio: { lte: end },
+        data_fim: { gte: start },
+        OR: [{ turmaId: null }, { turmaId: matriculaAtiva.turmaId }],
+      },
+      include: {
+        turma: { select: { nome: true } },
+      },
+    }),
+  ]);
+
+  const eventos: AgendaEvento[] = [];
+
+  for (
+    let current = startOfDay(start);
+    current.getTime() <= end.getTime();
+    current = addDays(current, 1)
+  ) {
+    const diaSemanaAtual = current.getDay();
+
+    horarios.forEach((horario) => {
+      const diaHorario = diaSemanaMap[horario.dia_semana as DiaDaSemana];
+      if (diaHorario === diaSemanaAtual) {
+        eventos.push({
+          id: `aula-${horario.id}-${formatDateKey(current)}`,
+          date: new Date(current),
+          type: "Aula",
+          title:
+            horario.componenteCurricular?.materia?.nome ||
+            horario.turma?.nome ||
+            "Aula",
+          details: horario.turma?.nome || undefined,
+          time: `${horario.hora_inicio} - ${horario.hora_fim}`,
+        });
+      }
+    });
+  }
+
+  tarefas.forEach((tarefa) => {
+    const entrega = new Date(tarefa.data_entrega);
+    const tipo =
+      tipoMap[String(tarefa.tipo).toUpperCase()] ||
+      (tarefa.tipo === "PROVA"
+        ? "Prova"
+        : tarefa.tipo === "TRABALHO"
+        ? "Trabalho"
+        : "Tarefa");
+
+    eventos.push({
+      id: `tarefa-${tarefa.id}`,
+      date: entrega,
+      type: tipo,
+      title: tarefa.titulo,
+      details: tarefa.componenteCurricular?.materia?.nome || undefined,
+      time: formatTime(entrega),
+    });
+  });
+
+  eventosGerais.forEach((evento) => {
+    const inicioOriginal = new Date(evento.data_inicio);
+    const fimOriginal = evento.data_fim
+      ? new Date(evento.data_fim)
+      : new Date(evento.data_inicio);
+
+    const inicio = startOfDay(inicioOriginal < start ? start : inicioOriginal);
+    const fim = startOfDay(fimOriginal > end ? end : fimOriginal);
+
+    for (
+      let dia = new Date(inicio);
+      dia.getTime() <= fim.getTime();
+      dia = addDays(dia, 1)
+    ) {
+      const isPrimeiroDia =
+        formatDateKey(dia) === formatDateKey(startOfDay(inicioOriginal));
+
+      eventos.push({
+        id: `evento-${evento.id}-${formatDateKey(dia)}`,
+        date: new Date(dia),
+        type: tipoMap[String(evento.tipo).toUpperCase()] || "Evento Escolar",
+        title: evento.titulo,
+        details:
+          [evento.descricao, evento.turma?.nome].filter(Boolean).join(" • ") ||
+          undefined,
+        time: evento.dia_inteiro
+          ? "Dia inteiro"
+          : isPrimeiroDia
+          ? formatTime(inicioOriginal)
+          : undefined,
+      });
+    }
+  });
+
+  eventos.sort((a, b) => {
+    const diff = a.date.getTime() - b.date.getTime();
+    if (diff !== 0) return diff;
+
+    const horaA = a.time?.slice(0, 5) || "";
+    const horaB = b.time?.slice(0, 5) || "";
+    return horaA.localeCompare(horaB);
+  });
+
+  return eventos.map((evento) => ({
+    ...evento,
+    date: evento.date.toISOString(),
+  }));
+}
+
 export const alunoService = {
   findAllPerfis,
   findOne: findOneByUserId,
   getBoletim,
+  getAgendaEventos,
 };

--- a/frontend/src/app/aluno/agenda/agenda.module.css
+++ b/frontend/src/app/aluno/agenda/agenda.module.css
@@ -40,6 +40,38 @@
   display: inline-block;
 }
 
+.errorBanner {
+  max-width: 1100px;
+  margin: 0 auto 16px auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  background: rgba(239, 68, 68, 0.1);
+  color: var(--cor-erro, #b91c1c);
+  font-weight: 600;
+}
+
+.errorIcon {
+  color: inherit;
+}
+
+.errorBannerIcon {
+  font-size: 18px;
+}
+
+.errorStateIcon {
+  font-size: 32px;
+}
+
+.errorState {
+  color: var(--cor-erro, #b91c1c);
+  text-align: center;
+  font-weight: 600;
+}
+
 /* Layout: calendar + side panel */
 .wrapper {
   max-width: 1100px;

--- a/frontend/src/app/aluno/agenda/page.tsx
+++ b/frontend/src/app/aluno/agenda/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   FaChevronLeft,
   FaChevronRight,
@@ -8,48 +8,10 @@ import {
   FaRegCalendar,
 } from 'react-icons/fa';
 import styles from './agenda.module.css';
-import { useAgendaMensal } from '@/hooks/agendaMensal/useAgendaMensal';
-
-export type EventoCalendario = {
-  id: string;
-  date: string | Date;
-  type:
-    | 'Aula'
-    | 'Prova'
-    | 'Trabalho'
-    | 'Tarefa'
-    | 'Recuperação'
-    | 'Reunião'
-    | 'Feriado'
-    | 'Evento Escolar';
-  title: string;
-  details?: string;
-  time?: string;
-};
-
-type ApiEvento = {
-  id: string;
-  data: string;
-  tipo: string;
-  titulo: string;
-  detalhes?: string;
-  horario?: string;
-};
-
-const MESES_PT = [
-  'Outubro',
-  'Novembro',
-  'Dezembro',
-  'Janeiro',
-  'Fevereiro',
-  'Março',
-  'Abril',
-  'Maio',
-  'Junho',
-  'Julho',
-  'Agosto',
-  'Setembro',
-];
+import {
+  useAgendaMensal,
+  type EventoCalendario,
+} from '@/hooks/agendaMensal/useAgendaMensal';
 function monthLabel(date: Date) {
   const formatter = new Intl.DateTimeFormat('pt-BR', {
     month: 'long',
@@ -91,31 +53,6 @@ function getMonthMatrix(viewDate: Date) {
     days.push(atMidnight(d));
   }
   return { days, start, end };
-}
-
-function mapApiToEvento(a: ApiEvento): EventoCalendario {
-  const mapTipo: Record<string, EventoCalendario['type']> = {
-    AULA: 'Aula',
-    PROVA: 'Prova',
-    TRABALHO: 'Trabalho',
-    TAREFA: 'Tarefa',
-    RECUPERACAO: 'Recuperação',
-    REUNIAO: 'Reunião',
-    FERIADO: 'Feriado',
-    EVENTO_ESCOLAR: 'Evento Escolar',
-  };
-  const tipo =
-    mapTipo[a.tipo?.toUpperCase?.()] ??
-    (a.tipo as EventoCalendario['type']) ??
-    'Evento Escolar';
-  return {
-    id: a.id,
-    date: a.data,
-    type: tipo,
-    title: a.titulo,
-    details: a.detalhes,
-    time: a.horario,
-  };
 }
 
 export default function AgendaMensalAlunoPage() {
@@ -173,6 +110,15 @@ export default function AgendaMensalAlunoPage() {
           </span>
         </div>
       </header>
+
+      {!loading && error && (
+        <div className={styles.errorBanner} role="alert">
+          <FaCalendarAlt
+            className={`${styles.errorIcon} ${styles.errorBannerIcon}`}
+          />
+          <span>{error}</span>
+        </div>
+      )}
 
       <div className={styles.wrapper}>
         {/* Coluna esquerda: calendário */}
@@ -284,6 +230,13 @@ export default function AgendaMensalAlunoPage() {
             <div className={styles.empty}>
               <FaRegCalendar className={styles.emptyIcon} />
               <p>Carregando…</p>
+            </div>
+          ) : error ? (
+            <div className={`${styles.empty} ${styles.errorState}`}>
+              <FaCalendarAlt
+                className={`${styles.errorIcon} ${styles.errorStateIcon}`}
+              />
+              <p>{error}</p>
             </div>
           ) : eventosSelecionado.length === 0 ? (
             <div className={styles.empty}>

--- a/frontend/src/hooks/agendaMensal/useAgendaMensal.ts
+++ b/frontend/src/hooks/agendaMensal/useAgendaMensal.ts
@@ -4,10 +4,56 @@ import { api } from '@/services/api';
 export type EventoCalendario = {
   id: string;
   date: string;
-  type: 'Aula' | 'Prova' | 'Trabalho' | 'Tarefa' | 'Recuperação' | 'Reunião' | 'Feriado' | 'Evento Escolar';
+  type:
+    | 'Aula'
+    | 'Prova'
+    | 'Trabalho'
+    | 'Tarefa'
+    | 'Recuperação'
+    | 'Reunião'
+    | 'Feriado'
+    | 'Evento Escolar';
   title: string;
   details?: string;
   time?: string;
+};
+
+type ApiEvento = {
+  id: string;
+  date?: string;
+  data?: string;
+  type?: string;
+  tipo?: string;
+  title?: string;
+  titulo?: string;
+  details?: string;
+  descricao?: string;
+  time?: string;
+  horario?: string;
+};
+
+const mapApiEvento = (evento: ApiEvento): EventoCalendario => {
+  const tipo = (evento.type || evento.tipo || '').toUpperCase();
+  const tipoMap: Record<string, EventoCalendario['type']> = {
+    AULA: 'Aula',
+    PROVA: 'Prova',
+    TRABALHO: 'Trabalho',
+    TAREFA: 'Tarefa',
+    RECUPERACAO: 'Recuperação',
+    RECUPERACAO_FINAL: 'Recuperação',
+    REUNIAO: 'Reunião',
+    FERIADO: 'Feriado',
+    EVENTO_ESCOLAR: 'Evento Escolar',
+  };
+
+  return {
+    id: evento.id,
+    date: evento.date || evento.data || new Date().toISOString(),
+    type: tipoMap[tipo] || 'Evento Escolar',
+    title: evento.title || evento.titulo || 'Evento',
+    details: evento.details || evento.descricao,
+    time: evento.time || evento.horario,
+  };
 };
 
 export function useAgendaMensal(startISO: string, endISO: string) {
@@ -24,9 +70,20 @@ export function useAgendaMensal(startISO: string, endISO: string) {
         const { data } = await api.get('/aluno/agenda', {
           params: { start: startISO, end: endISO },
         });
-        if (alive) setEventos(data?.eventos ?? []);
+        if (!alive) return;
+        const eventosNormalizados: EventoCalendario[] = Array.isArray(
+          data?.eventos,
+        )
+          ? data.eventos.map(mapApiEvento)
+          : [];
+        setEventos(eventosNormalizados);
       } catch (e: any) {
-        if (alive) setError(e?.response?.data?.message || 'Falha ao carregar agenda.');
+        if (alive) {
+          setError(
+            e?.response?.data?.message || 'Falha ao carregar agenda.',
+          );
+          setEventos([]);
+        }
       } finally {
         if (alive) setLoading(false);
       }


### PR DESCRIPTION
## Summary
- add a protected `/aluno/agenda` endpoint that returns aulas, tarefas, provas e eventos no intervalo solicitado
- normalise agenda responses on the frontend hook and expose loading/error handling on the aluno monthly agenda screen
- refine the agenda UI with an error banner so students see API issues alongside the calendar

## Testing
- npm run lint *(fails: existing lint errors across unrelated frontend files)*

------
https://chatgpt.com/codex/tasks/task_e_69000ae282a4832bbcf25a719d93e444