### PR TITLE
feat: suporte a anexos de trabalhos via google drive

### DIFF
--- a/backend/src/modules/tarefa/tarefa.controller.ts
+++ b/backend/src/modules/tarefa/tarefa.controller.ts
@@ -1,4 +1,5 @@
 import { Response } from "express";
+import type { Express } from "express";
 import { tarefaService } from "./tarefa.service";
 import { AuthenticatedRequest } from "../../middlewares/auth";
 import {
@@ -91,6 +92,35 @@ export const tarefaController = {
       if ((error as any).code === "P2025")
         return res.status(404).json({ message: "Tarefa não encontrada." });
       return res.status(500).json({ message: "Erro ao deletar tarefa." });
+    }
+  },
+
+  uploadAttachments: async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const { id } = req.params;
+      const files = (req.files as Express.Multer.File[]) ?? [];
+
+      if (!files.length) {
+        return res
+          .status(400)
+          .json({ message: "Envie ao menos um arquivo para anexar." });
+      }
+
+      const anexos = await tarefaService.addAttachments(id, files, req.user);
+      return res.status(201).json({ anexos });
+    } catch (error: any) {
+      if ((error as any).code === "FORBIDDEN")
+        return res.status(403).json({ message: error.message });
+      if ((error as any).code === "P2025")
+        return res.status(404).json({ message: "Tarefa não encontrada." });
+
+      if (error instanceof Error && error.message.includes("anexo")) {
+        return res.status(400).json({ message: error.message });
+      }
+
+      return res.status(500).json({
+        message: error.message || "Erro ao anexar arquivos ao trabalho.",
+      });
     }
   },
 };

--- a/backend/src/modules/tarefa/tarefa.validator.ts
+++ b/backend/src/modules/tarefa/tarefa.validator.ts
@@ -35,6 +35,19 @@ export const createTarefaSchema = z.object({
         tipoTrabalho: z.string().optional(),
         permiteAnexos: z.boolean().optional(),
         requisitos: z.array(z.string()).optional(),
+        anexos: z
+          .array(
+            z.object({
+              id: z.string(),
+              nome: z.string(),
+              tipo: z.string(),
+              tamanho: z.number(),
+              url: z.string(),
+              visualizacaoUrl: z.string().optional(),
+              enviadoEm: z.string().optional(),
+            })
+          )
+          .optional(),
       })
       .optional(),
   }),

--- a/backend/src/services/googleDrive.service.ts
+++ b/backend/src/services/googleDrive.service.ts
@@ -1,0 +1,258 @@
+import { randomBytes } from "crypto";
+
+const GOOGLE_OAUTH_TOKEN_URL = "https://oauth2.googleapis.com/token";
+const GOOGLE_DRIVE_FILES_URL = "https://www.googleapis.com/drive/v3/files";
+const GOOGLE_DRIVE_UPLOAD_URL =
+  "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart";
+
+interface UploadFileInput {
+  buffer: Buffer;
+  mimeType: string;
+  name: string;
+}
+
+export interface GoogleDriveFile {
+  id: string;
+  nome: string;
+  tipo: string;
+  tamanho: number;
+  url: string;
+  visualizacaoUrl: string;
+  enviadoEm: string;
+}
+
+let cachedAccessToken: { token: string; expiresAt: number } | null = null;
+let cachedFolderId: string | null = null;
+
+const clientId =
+  process.env.GOOGLE_DRIVE_CLIENT_ID ??
+  "34172535407-i467kkn72q9mgfadfapf9kpi87u96gr8.apps.googleusercontent.com";
+const clientSecret =
+  process.env.GOOGLE_DRIVE_CLIENT_SECRET ??
+  "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";
+const redirectUri =
+  process.env.GOOGLE_DRIVE_REDIRECT_URI ?? "http://localhost:4000";
+const refreshToken = process.env.GOOGLE_DRIVE_REFRESH_TOKEN;
+const folderName =
+  process.env.GOOGLE_DRIVE_FOLDER_NAME ?? "anexos_educacaoSass";
+
+async function getAccessToken(): Promise<string> {
+  if (cachedAccessToken && cachedAccessToken.expiresAt > Date.now()) {
+    return cachedAccessToken.token;
+  }
+
+  if (!refreshToken) {
+    throw new Error(
+      "Token de atualização do Google Drive não configurado. Defina GOOGLE_DRIVE_REFRESH_TOKEN."
+    );
+  }
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: "refresh_token",
+    redirect_uri: redirectUri,
+  });
+
+  const response = await fetch(GOOGLE_OAUTH_TOKEN_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: params.toString(),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(
+      `Não foi possível obter um token de acesso do Google Drive: ${error}`
+    );
+  }
+
+  const data = (await response.json()) as {
+    access_token: string;
+    expires_in: number;
+  };
+
+  cachedAccessToken = {
+    token: data.access_token,
+    expiresAt: Date.now() + (data.expires_in - 60) * 1000,
+  };
+
+  return data.access_token;
+}
+
+async function ensureFolder(accessToken: string): Promise<string> {
+  if (cachedFolderId) {
+    return cachedFolderId;
+  }
+
+  const query = new URLSearchParams({
+    q: `name='${folderName}' and mimeType='application/vnd.google-apps.folder' and trashed=false`,
+    fields: "files(id, name)",
+    pageSize: "1",
+  });
+
+  const listResponse = await fetch(`${GOOGLE_DRIVE_FILES_URL}?${query}`, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  if (!listResponse.ok) {
+    const error = await listResponse.text();
+    throw new Error(`Erro ao verificar pasta no Google Drive: ${error}`);
+  }
+
+  const listData = (await listResponse.json()) as {
+    files?: Array<{ id: string; name: string }>;
+  };
+
+  if (listData.files && listData.files.length > 0) {
+    cachedFolderId = listData.files[0].id;
+    return cachedFolderId;
+  }
+
+  const createResponse = await fetch(GOOGLE_DRIVE_FILES_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      name: folderName,
+      mimeType: "application/vnd.google-apps.folder",
+    }),
+  });
+
+  if (!createResponse.ok) {
+    const error = await createResponse.text();
+    throw new Error(`Erro ao criar pasta no Google Drive: ${error}`);
+  }
+
+  const createdData = (await createResponse.json()) as { id: string };
+  cachedFolderId = createdData.id;
+  return createdData.id;
+}
+
+async function setFilePermissions(accessToken: string, fileId: string) {
+  const response = await fetch(
+    `${GOOGLE_DRIVE_FILES_URL}/${fileId}/permissions`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ role: "reader", type: "anyone" }),
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Erro ao configurar permissões do arquivo: ${error}`);
+  }
+}
+
+async function fetchFileMetadata(accessToken: string, fileId: string) {
+  const params = new URLSearchParams({
+    fields: "id,name,mimeType,size,webViewLink,webContentLink",
+  });
+
+  const response = await fetch(
+    `${GOOGLE_DRIVE_FILES_URL}/${fileId}?${params.toString()}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Erro ao buscar metadados do arquivo: ${error}`);
+  }
+
+  return (await response.json()) as {
+    id: string;
+    name: string;
+    mimeType: string;
+    size?: string;
+    webViewLink?: string;
+    webContentLink?: string;
+  };
+}
+
+export async function uploadFile({
+  buffer,
+  mimeType,
+  name,
+}: UploadFileInput): Promise<GoogleDriveFile> {
+  const accessToken = await getAccessToken();
+  const folderId = await ensureFolder(accessToken);
+
+  const boundary = `drive-boundary-${randomBytes(12).toString("hex")}`;
+  const delimiter = `\r\n--${boundary}\r\n`;
+  const closeDelimiter = `\r\n--${boundary}--`;
+
+  const metadataPart = Buffer.from(
+    `${delimiter}Content-Type: application/json; charset=UTF-8\r\n\r\n${JSON.stringify({
+      name,
+      parents: [folderId],
+    })}`
+  );
+
+  const fileHeader = Buffer.from(
+    `${delimiter}Content-Type: ${mimeType}\r\n\r\n`
+  );
+
+  const requestBody = Buffer.concat([
+    metadataPart,
+    fileHeader,
+    buffer,
+    Buffer.from(closeDelimiter),
+  ]);
+
+  const uploadResponse = await fetch(GOOGLE_DRIVE_UPLOAD_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": `multipart/related; boundary=${boundary}`,
+      "Content-Length": requestBody.length.toString(),
+    },
+    body: requestBody,
+  });
+
+  if (!uploadResponse.ok) {
+    const error = await uploadResponse.text();
+    throw new Error(`Erro ao enviar arquivo para o Google Drive: ${error}`);
+  }
+
+  const uploadData = (await uploadResponse.json()) as { id: string };
+
+  await setFilePermissions(accessToken, uploadData.id);
+  const metadata = await fetchFileMetadata(accessToken, uploadData.id);
+
+  const fileSize = metadata.size ? Number(metadata.size) : buffer.length;
+  const downloadUrl =
+    metadata.webContentLink ??
+    `https://drive.google.com/uc?export=download&id=${metadata.id}`;
+  const viewUrl =
+    metadata.webViewLink ??
+    `https://drive.google.com/file/d/${metadata.id}/view`;
+
+  return {
+    id: metadata.id,
+    nome: metadata.name,
+    tipo: metadata.mimeType,
+    tamanho: fileSize,
+    url: downloadUrl,
+    visualizacaoUrl: viewUrl,
+    enviadoEm: new Date().toISOString(),
+  };
+}
+
+export const googleDriveService = {
+  uploadFile,
+};

--- a/frontend/src/app/aluno/trabalhos/page.tsx
+++ b/frontend/src/app/aluno/trabalhos/page.tsx
@@ -16,6 +16,24 @@ import {
 import Link from 'next/link';
 import Pagination from '@/components/paginacao/Paginacao';
 
+function formatFileSize(bytes?: number) {
+  if (!bytes) return '—';
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const index = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+    units.length - 1,
+  );
+  const size = bytes / Math.pow(1024, index);
+  return `${size.toFixed(size >= 10 || index === 0 ? 0 : 1)} ${units[index]}`;
+}
+
+function getFileExtension(name: string) {
+  const parts = name.split('.');
+  if (parts.length <= 1) return '';
+  return parts[parts.length - 1];
+}
+
 export default function AtividadesPostadasPage() {
   const {
     error,
@@ -210,23 +228,43 @@ export default function AtividadesPostadasPage() {
                   </ul>
                 </div>
 
-                {trabalhoSelecionado.metadata?.permiteAnexos && (
-                  <div className={styles.anexo}>
-                    <h3>Anexo</h3>
-                    <div>
-                      <div className={styles.anexoItens}>
-                        <div className={styles.icone}>
-                          <LuFileText />
-                        </div>
-                        <div className={styles.infoAnexo}>
-                          <h4>Trabalho_anexo.pdf</h4>
-                          <p>
-                            PDF <span>2.4 MB</span>
-                          </p>
-                        </div>
-                      </div>
-                      <LuDownload className={styles.iconeDawnload} />
-                    </div>
+                {(trabalhoSelecionado.metadata?.anexos?.length ?? 0) > 0 && (
+                  <div className={styles.anexos}>
+                    <h3>Anexos</h3>
+                    <ul className={styles.anexoLista}>
+                      {trabalhoSelecionado.metadata?.anexos?.map((anexo) => {
+                        const extensao = getFileExtension(anexo.nome);
+                        const extensaoLabel = extensao
+                          ? extensao.toUpperCase()
+                          : 'ARQUIVO';
+                        return (
+                          <li key={anexo.id}>
+                            <div className={styles.anexoItens}>
+                              <div className={styles.icone}>
+                                <LuFileText />
+                              </div>
+                              <div className={styles.infoAnexo}>
+                                <h4>{anexo.nome}</h4>
+                                <p>
+                                  {extensaoLabel}
+                                  {' '}
+                                  <span>{formatFileSize(anexo.tamanho)}</span>
+                                </p>
+                              </div>
+                            </div>
+                            <a
+                              href={anexo.url || anexo.visualizacaoUrl || '#'}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className={styles.downloadLink}
+                              aria-label={`Baixar ${anexo.nome}`}
+                            >
+                              <LuDownload className={styles.iconeDownload} />
+                            </a>
+                          </li>
+                        );
+                      })}
+                    </ul>
                   </div>
                 )}
 

--- a/frontend/src/app/aluno/trabalhos/trabalhos.module.css
+++ b/frontend/src/app/aluno/trabalhos/trabalhos.module.css
@@ -254,11 +254,17 @@
   border: 1px solid color-mix(in srgb, currentColor 30%, white 70%);
 }
 
-.anexo {
+.anexos {
   margin-bottom: 30px;
 }
 
-.anexo > div {
+.anexoLista {
+  display: flex;
+  flex-direction: column;
+  gap: 15px;
+}
+
+.anexoLista li {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -266,7 +272,7 @@
   padding: 20px;
   border: 1px solid var(--cor-borda);
   border-radius: 15px;
-  cursor: pointer;
+  background-color: white;
 }
 
 .anexoItens {
@@ -274,7 +280,7 @@
   gap: 20px;
 }
 
-.anexo .icone {
+.anexoItens .icone {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -284,7 +290,7 @@
   background-color: var(--cor-perigo-light);
 }
 
-.anexo .icone svg {
+.anexoItens .icone svg {
   color: var(--cor-perigo);
   font-size: 1.5rem;
 }
@@ -318,7 +324,24 @@
   top: 6px;
 }
 
-.anexo .iconeDawnload {
+.downloadLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background-color: var(--cor-primaria-light);
+  color: var(--cor-primaria);
+  transition: background-color 0.2s, color 0.2s;
+}
+
+.downloadLink:hover {
+  background-color: var(--cor-primaria);
+  color: white;
+}
+
+.iconeDownload {
   font-size: 1.3rem;
 }
 

--- a/frontend/src/app/professor/trabalhos/nova/novo-trabalho.module.css
+++ b/frontend/src/app/professor/trabalhos/nova/novo-trabalho.module.css
@@ -71,6 +71,74 @@
   transition: border-color 0.2s;
 }
 
+.attachmentInputRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.attachmentInputRow input[type="file"] {
+  padding: 0.75rem;
+  border: 1px dashed var(--cor-primaria);
+  border-radius: 8px;
+  background-color: var(--cor-fundo-card);
+  cursor: pointer;
+}
+
+.attachmentInputRow span {
+  color: var(--cor-subtexto);
+  font-size: 0.9rem;
+}
+
+.attachmentList {
+  margin-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.attachmentList li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--cor-borda);
+  border-radius: 8px;
+  background-color: var(--cor-fundo-card);
+}
+
+.attachmentList li div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.attachmentList li p {
+  font-weight: 500;
+  color: var(--cor-texto);
+}
+
+.attachmentList li span {
+  font-size: 0.85rem;
+  color: var(--cor-subtexto);
+}
+
+.removeAttachmentButton {
+  border: none;
+  background: transparent;
+  color: var(--cor-perigo);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: color 0.2s;
+}
+
+.removeAttachmentButton:hover {
+  color: var(--cor-perigo-hover, #a00);
+}
+
 .field input:focus,
 .field select:focus,
 .field textarea:focus {

--- a/frontend/src/types/tarefas.ts
+++ b/frontend/src/types/tarefas.ts
@@ -1,9 +1,27 @@
-export type TipoTrabalho = 'PESQUISA' | 'RESENHA' | 'APRESENTACAO' | 'OUTRO';
+export type TipoTrabalho =
+  | 'PESQUISA'
+  | 'RESUMO'
+  | 'RESENHA'
+  | 'APRESENTACAO'
+  | 'PROJETO'
+  | 'RELATORIO'
+  | 'OUTRO';
+
+export interface TarefaAnexo {
+  id: string;
+  nome: string;
+  tipo: string;
+  tamanho: number;
+  url: string;
+  visualizacaoUrl?: string;
+  enviadoEm?: string;
+}
 
 export interface TarefaMetadata {
-  tipoTrabalho: TipoTrabalho;
-  permiteAnexos: boolean;
-  requisitos: string[];
+  tipoTrabalho?: TipoTrabalho;
+  permiteAnexos?: boolean;
+  requisitos?: string[];
+  anexos?: TarefaAnexo[];
 }
 
 export type ApiTarefa = {


### PR DESCRIPTION
## Summary
- integrar upload de anexos ao Google Drive com novos serviços e rota protegida para tarefas
- garantir persistência dos metadados de anexos na tarefa após o upload
- permitir que professores anexem arquivos ao criar trabalhos e que alunos visualizem e baixem esses anexos na interface

## Testing
- `npm run build` *(falha: o projeto já possuía diversos erros de tipagem no backend)*
- `npm run lint` *(falha: o frontend já possuía centenas de avisos/erros de linting pré-existentes)*

------
https://chatgpt.com/codex/tasks/task_e_69029a4e4324832ba6915dc22b879aa3