### PR TITLE
Revamp student weekly agenda dashboard

### DIFF
--- a/frontend/src/components/aluno/dashboard/agendaSemanal/AgendaSemanalAluno.tsx
+++ b/frontend/src/components/aluno/dashboard/agendaSemanal/AgendaSemanalAluno.tsx
@@ -1,7 +1,17 @@
 'use client';
 
 import { useState, useEffect, useMemo } from 'react';
-import { FaCalendarAlt } from 'react-icons/fa';
+import {
+  FaCalendarAlt,
+  FaChalkboardTeacher,
+  FaClipboardList,
+  FaRedo,
+  FaUsers,
+  FaUmbrellaBeach,
+  FaRegStar,
+  FaPen,
+} from 'react-icons/fa';
+import type { IconType } from 'react-icons';
 import styles from './styles.module.css';
 
 // Para conveniência, mantive o tipo aqui como no seu exemplo.
@@ -26,26 +36,48 @@ interface AgendaProps {
   eventos: EventoCalendario[];
 }
 
-const diasDaSemanaNomes = ['Dom', 'Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb'];
+const diasDaSemanaNomes = ['Seg', 'Ter', 'Qua', 'Qui', 'Sex', 'Sáb', 'Dom'];
 const MAX_VISIBLE_EVENTS_PER_DAY = 3;
+
+const eventTypeMeta: Record<
+  EventoCalendario['type'],
+  { label: string; icon: IconType; badgeClass: string }
+> = {
+  Aula: { label: 'Aula', icon: FaChalkboardTeacher, badgeClass: 'aula' },
+  Prova: { label: 'Prova', icon: FaPen, badgeClass: 'prova' },
+  Trabalho: { label: 'Trabalho', icon: FaClipboardList, badgeClass: 'trabalho' },
+  Recuperação: { label: 'Recuperação', icon: FaRedo, badgeClass: 'recuperacao' },
+  Reunião: { label: 'Reunião', icon: FaUsers, badgeClass: 'reuniao' },
+  Feriado: { label: 'Feriado', icon: FaUmbrellaBeach, badgeClass: 'feriado' },
+  'Evento Escolar': {
+    label: 'Evento Escolar',
+    icon: FaRegStar,
+    badgeClass: 'evento_escolar',
+  },
+};
 
 export default function AgendaSemanalAluno({ eventos = [] }: AgendaProps) {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [weekDays, setWeekDays] = useState<{ date: Date; dayNumber: string }[]>(
     [],
   );
+  const todayString = useMemo(() => new Date().toDateString(), []);
 
   useEffect(() => {
     const today = new Date();
-    const startOfWeek = new Date(
-      today.setDate(today.getDate() - today.getDay()),
-    );
+    const startOfWeek = new Date(today);
+    const currentWeekDay = startOfWeek.getDay();
+    const diff =
+      startOfWeek.getDate() - currentWeekDay + (currentWeekDay === 0 ? -6 : 1);
+    startOfWeek.setDate(diff);
+
     const days = [];
     for (let i = 0; i < 7; i++) {
       const date = new Date(startOfWeek);
       date.setDate(startOfWeek.getDate() + i);
       days.push({ date, dayNumber: date.getDate().toString() });
     }
+
     setWeekDays(days);
     setSelectedDate(new Date());
   }, []);
@@ -74,23 +106,23 @@ export default function AgendaSemanalAluno({ eventos = [] }: AgendaProps) {
       <div className={styles.weekContainer}>
         {weekDays.map(({ date, dayNumber }, index) => {
           const eventosDoDia = getEventosDoDia(date);
-          const visibleEvents = eventosDoDia.slice(
-            0,
-            MAX_VISIBLE_EVENTS_PER_DAY - 1,
-          );
+          const visibleEvents = eventosDoDia.slice(0, MAX_VISIBLE_EVENTS_PER_DAY);
           const remainingCount = eventosDoDia.length - visibleEvents.length;
+          const isSelected = selectedDate.toDateString() === date.toDateString();
+          const isToday = todayString === date.toDateString();
 
           return (
             <div
               key={index}
               className={`${styles.day} ${
-                selectedDate.toDateString() === date.toDateString()
-                  ? styles.selected
-                  : ''
+                isSelected ? styles.selected : ''
               }`}
               onClick={() => setSelectedDate(date)}
             >
-              <span className={styles.dayName}>{diasDaSemanaNomes[index]}</span>
+              <div className={styles.dayHeader}>
+                <span className={styles.dayName}>{diasDaSemanaNomes[index]}</span>
+                {isToday && <span className={styles.todayBadge}>Hoje</span>}
+              </div>
               <span className={styles.dayNumber}>{dayNumber}</span>
 
               <div className={styles.dayEventsContainer}>
@@ -98,9 +130,13 @@ export default function AgendaSemanalAluno({ eventos = [] }: AgendaProps) {
                   <div
                     key={evento.id}
                     className={`${styles.dayEventTag} ${
-                      styles[evento.type.toLowerCase().replace(' ', '_')]
+                      styles[
+                        eventTypeMeta[evento.type].badgeClass as keyof typeof styles
+                      ]
                     }`}
-                  ></div>
+                  >
+                    {eventTypeMeta[evento.type].label}
+                  </div>
                 ))}
                 {remainingCount > 0 && (
                   <div
@@ -118,16 +154,50 @@ export default function AgendaSemanalAluno({ eventos = [] }: AgendaProps) {
       <hr className={styles.divider} />
       <div className={styles.scheduleContainer}>
         {eventosDoDiaSelecionado.length > 0 ? (
-          eventosDoDiaSelecionado.map((evento) => (
-            <div
-              key={evento.id}
-              className={`${styles.classItem} ${
-                styles[evento.type.toLowerCase().replace(' ', '_')]
-              }`}
-            >
-              {evento.title}
-            </div>
-          ))
+          eventosDoDiaSelecionado.map((evento) => {
+            const EventoIcon = eventTypeMeta[evento.type].icon;
+
+            return (
+              <div key={evento.id} className={styles.eventCard}>
+                <div
+                  className={`${styles.eventBadge} ${
+                    styles[
+                      eventTypeMeta[evento.type].badgeClass as keyof typeof styles
+                    ]
+                  }`}
+                >
+                  <EventoIcon />
+                </div>
+
+                <div className={styles.eventContent}>
+                  <div className={styles.eventHeader}>
+                    <h3>{evento.title}</h3>
+                    <span
+                      className={`${styles.eventType} ${
+                        styles[
+                          eventTypeMeta[evento.type]
+                            .badgeClass as keyof typeof styles
+                        ]
+                      }`}
+                    >
+                      {eventTypeMeta[evento.type].label}
+                    </span>
+                  </div>
+
+                  {(evento.time || evento.details) && (
+                    <div className={styles.eventMeta}>
+                      {evento.time && (
+                        <span className={styles.eventTime}>{evento.time}</span>
+                      )}
+                      {evento.details && (
+                        <span className={styles.eventDetails}>{evento.details}</span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              </div>
+            );
+          })
         ) : (
           <p className={styles.noClasses}>Nenhuma atividade para hoje.</p>
         )}

--- a/frontend/src/components/aluno/dashboard/agendaSemanal/styles.module.css
+++ b/frontend/src/components/aluno/dashboard/agendaSemanal/styles.module.css
@@ -1,9 +1,13 @@
 .container {
   background-color: var(--cor-fundo-card);
   grid-row: 2 / 3;
-  border-radius: 15px;
-  padding: 1.5rem;
+  border-radius: 20px;
+  padding: 1.75rem;
   border: 1px solid var(--cor-borda);
+  box-shadow: 0 20px 45px -28px rgba(19, 33, 68, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 .header {
@@ -11,134 +15,268 @@
   align-items: center;
   gap: 0.75rem;
   color: var(--cor-texto-destaque);
-  margin-bottom: 1.5rem;
 }
 
 .header svg {
-  font-size: 1.2rem;
+  font-size: 1.5rem;
   color: var(--cor-primaria);
 }
 
 .header h2 {
-  font-size: 1.2rem;
+  font-size: 1.4rem;
   font-weight: 600;
-  font-weight: 500;
 }
 
 .weekContainer {
-  display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
 }
 
 .day {
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem;
-  border-radius: 8px;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 16px;
   cursor: pointer;
-  transition: background-color 0.2s ease;
-  flex-basis: 0;
-  flex-grow: 1;
-  min-height: 120px;
-}
-
-.dayName {
-  font-size: 0.8rem;
-  color: var(--cor-subtexto);
-  font-weight: 500;
-}
-
-.dayNumber {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--cor-texto-destaque);
-  width: 28px;
-  height: 28px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: 10px;
-  transition: all 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  border: 1px solid transparent;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.25), rgba(255, 255, 255, 0.05));
 }
 
 .day:hover {
-  background-color: #f0f0f0;
+  transform: translateY(-2px);
+  box-shadow: 0 12px 25px -20px rgba(19, 33, 68, 0.45);
+}
+
+.day.selected {
+  border-color: rgba(66, 133, 244, 0.35);
+  box-shadow: 0 16px 35px -24px rgba(66, 133, 244, 0.55);
+  background: linear-gradient(180deg, rgba(66, 133, 244, 0.08), rgba(255, 255, 255, 0.05));
+}
+
+.day.selected .dayName {
+  color: var(--cor-primaria);
 }
 
 .day.selected .dayNumber {
-  background-color: var(--cor-primaria);
+  background: var(--cor-primaria);
   color: white;
+  border-color: transparent;
+  box-shadow: 0 10px 22px -18px rgba(66, 133, 244, 0.85);
 }
-.dayEventsContainer {
-  margin-top: 0.5rem;
+
+.dayHeader {
   display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.dayName {
+  font-size: 0.9rem;
+  color: var(--cor-subtexto);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.todayBadge {
+  font-size: 0.7rem;
+  background-color: rgba(66, 133, 244, 0.15);
+  color: var(--cor-primaria);
+  padding: 0.2rem 0.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.dayNumber {
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: var(--cor-texto-destaque);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 48px;
+  width: 48px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.45);
+  border: 1px solid rgba(19, 33, 68, 0.08);
+}
+
+.dayEventsContainer {
+  display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.35rem;
   width: 100%;
 }
 
 .dayEventTag {
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  background-color: var(--cor-primaria-light);
-  padding: 4px 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
   font-size: 0.7rem;
-  font-weight: 500;
-  text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: white;
+  box-shadow: 0 6px 12px -10px rgba(0, 0, 0, 0.45);
+}
+
+.moreEventsTag {
+  background-color: rgba(19, 33, 68, 0.15);
+  color: var(--cor-texto-destaque);
+  border: 1px dashed rgba(19, 33, 68, 0.35);
+  box-shadow: none;
 }
 
 .divider {
   border: none;
   border-top: 1px solid var(--cor-borda);
-  margin: 1.5rem 0;
+  margin: 0;
 }
 
 .scheduleContainer {
   display: flex;
-  flex-wrap: wrap;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.eventCard {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 18px;
+  border: 1px solid rgba(19, 33, 68, 0.08);
+  box-shadow: 0 18px 40px -32px rgba(19, 33, 68, 0.6);
+}
+
+.eventBadge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  color: white;
+  font-size: 1.3rem;
+}
+
+.eventContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.eventHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
   gap: 0.75rem;
 }
 
-.classItem {
+.eventHeader h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--cor-texto-destaque);
+}
+
+.eventType {
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
   color: white;
-  padding: 0.5rem 1rem;
-  border-radius: 10px;
+  box-shadow: 0 10px 22px -16px rgba(0, 0, 0, 0.6);
+}
+
+.eventMeta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   font-size: 0.9rem;
-  font-weight: 500;
+  color: var(--cor-subtexto);
+}
+
+.eventTime {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--cor-texto-destaque);
+}
+
+.eventDetails {
+  max-width: 100%;
+  opacity: 0.85;
 }
 
 .noClasses {
-  font-size: 0.9rem;
+  font-size: 0.95rem;
   color: var(--cor-subtexto);
-  width: 100%;
   text-align: center;
+  padding: 2rem 0;
 }
+
 .aula {
-  background-color: var(--cor-primaria);
+  background: linear-gradient(135deg, #4285f4, #5c9dff);
 }
+
 .prova {
-  background-color: #fc5659ff !important;
+  background: linear-gradient(135deg, #f65354, #ff7b7c);
 }
+
 .trabalho {
-  background-color: #ff9307;
+  background: linear-gradient(135deg, #ff8f3c, #ffb347);
 }
-.reunião {
-  background-color: #a857e2;
+
+.recuperacao {
+  background: linear-gradient(135deg, #34a853, #52c271);
 }
+
+.reuniao {
+  background: linear-gradient(135deg, #a855f7, #c084fc);
+}
+
 .feriado {
-  background-color: #6b7280;
+  background: linear-gradient(135deg, #6b7280, #9ca3af);
 }
-.recuperação {
-  background-color: var(--cor-aviso);
-}
+
 .evento_escolar {
-  background-color: var(--cor-icons-background);
+  background: linear-gradient(135deg, #0ea5e9, #38bdf8);
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 1.25rem;
+  }
+
+  .weekContainer {
+    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  }
+
+  .day {
+    padding: 0.75rem;
+  }
+
+  .eventCard {
+    grid-template-columns: 1fr;
+  }
+
+  .eventBadge {
+    width: 42px;
+    height: 42px;
+  }
+
+  .eventHeader {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }


### PR DESCRIPTION
## Summary
- redesign the student weekly agenda component to surface event type metadata with icons and color-coded badges
- adjust weekly navigation to start on Monday, highlight the current day, and display clearer event counts per day
- refresh the detailed schedule layout with richer styling for readability and context

## Testing
- npm run lint *(fails: existing repository lint errors outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_690412994698832b83207483bba74181